### PR TITLE
mdss: Only update the panel status after initializing

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -710,7 +710,6 @@ int mdss_dsi_on(struct mdss_panel_data *pdata)
 		pdata->panel_info.panel_power_on = 0;
 		return ret;
 	}
-	pdata->panel_info.panel_power_on = 1;
 
 	mdss_dsi_phy_sw_reset((ctrl_pdata->ctrl_base));
 	mdss_dsi_phy_init(pdata);
@@ -744,6 +743,7 @@ int mdss_dsi_on(struct mdss_panel_data *pdata)
 	if (pdata->panel_info.type == MIPI_CMD_PANEL)
 		mdss_dsi_clk_ctrl(ctrl_pdata, DSI_ALL_CLKS, 0);
 
+	pdata->panel_info.panel_power_on = 1;
 	pr_debug("%s-:\n", __func__);
 	return 0;
 }


### PR DESCRIPTION
The livedisplay driver is using this flag to check whether the panel is
on to either perform work or ignore it.

However, the flag is being set to on before initialization completes and
causes glitches when turning on the screen while using livedisplay. This
patch moves the flag to the end of the initialization.

Change-Id: I4d67376a0f799537e5ed9979dbf061b5b4a3e13a