### PR TITLE
fpc1020: Disable wake-up interrupt during probe

### DIFF
--- a/drivers/input/fingerprint/fpc/fpc1020_common.h
+++ b/drivers/input/fingerprint/fpc/fpc1020_common.h
@@ -320,7 +320,7 @@ typedef struct {
     struct work_struct input_report_work;
     struct workqueue_struct *fpc1020_wq;
     int report_key;
-    u8 wakeup_status;
+	u8 wakeup;
 	bool down;
 #endif
 


### PR DESCRIPTION
enable_irq must be called prior to enable_irq_wake
otherwise the interrupt will never be handled
and system will failed to suspend.

Let do the enable_irq_wake after enable_irq only.

HAM-1509

Change-Id: I64f9be41710330fb9c9bdbbc1d5b5249bb72be1e